### PR TITLE
2.0.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ dist/
 
 .idea
 src/**/*.js
+test.js
 

--- a/Readme.md
+++ b/Readme.md
@@ -86,15 +86,15 @@ After that you can use dispatcher to control pool manager.
 ## Simple Demo
 
 ```typescript
-import { ContextMode, PuppeteerPool } from "@hoplin/puppeteer-pool";
+import { ContextMode, PuppeteerPool } from '@hoplin/puppeteer-pool';
 
 async function main() {
   const poolInstance = await PuppeteerPool.start(5, ContextMode.ISOLATED);
 
   const urls = [
-    "https://www.google.com",
-    "https://www.bing.com",
-    "https://www.yahoo.com",
+    'https://www.google.com',
+    'https://www.bing.com',
+    'https://www.yahoo.com',
   ];
 
   console.log(await poolInstance.getPoolMetrics());
@@ -103,7 +103,7 @@ async function main() {
     poolInstance.runTask(async (page) => {
       await page.goto(url);
       return await page.title();
-    })
+    }),
   );
 
   const titles = await Promise.all(promises);
@@ -111,7 +111,6 @@ async function main() {
 }
 
 main();
-
 ```
 
 ## Support
@@ -138,28 +137,18 @@ Default config should be `puppeteer-pool-config.json` in root directory path.
 If config file are not given or invalid path, manager will use default defined configurations. Or if you want to pass
 config path, you can pass path to `bootPoolManager` function as parameter.
 
-```typescript
+```json
 {
-  session_pool: {
-    width: 1080,
-      height
-  :
-    1024,
+  "session_pool": {
+    "width": 1080,
+    "height": 1024
+  },
+  "threshold": {
+    "activate": true,
+    "interval": 5,
+    "cpu": 80,
+    "memory": 2048
   }
-,
-  threshold: {
-    activate: true,
-      interval
-  :
-    5,
-      cpu
-  :
-    80,
-      memory
-  :
-    2048,
-  }
-,
 }
 ```
 

--- a/Readme.md
+++ b/Readme.md
@@ -38,50 +38,50 @@ After that you can use dispatcher to control pool manager.
 **[ Client API ]**
 
 - PuppeteePool
-    - `PuppeteerPool` is singleton class. You can use `PuppeteerPool.start` to initialize pool manager.
+  - `PuppeteerPool` is singleton class. You can use `PuppeteerPool.start` to initialize pool manager.
 - PuppeteerPool.start
-    - Static Method
-    - Description: Initialize pool manager. You need to call this function to start puppeteer pool. Even if you invoke
-      this function multiple times with differenct arguments, it will return the first initialized instance.
-    - Args
-        - concurrencyLevel
-            - Required
-            - number
-        - contextMode: ContextMode
-            - Required
-            - ContextMode.ISOLATED | ContextMode.SHARED
-        - options
-            - Optional
-            - [puppeteer.LaunchOptions](https://pptr.dev/api/puppeteer.launchoptions)
-        - customConfigPath
-            - Optional
-            - string (Default: `puppeteer-pool-config.json` in project root)
-    - Return
-        - `Promise<PuppeteerPool>`
-        - Returns PuppeteerPool Instance.
+  - Static Method
+  - Description: Initialize pool manager. You need to call this function to start puppeteer pool. Even if you invoke
+    this function multiple times with differenct arguments, it will return the first initialized instance.
+  - Args
+    - concurrencyLevel
+      - Required
+      - number
+    - contextMode: ContextMode
+      - Required
+      - ContextMode.ISOLATED | ContextMode.SHARED
+    - options
+      - Optional
+      - [puppeteer.LaunchOptions](https://pptr.dev/api/puppeteer.launchoptions)
+    - customConfigPath
+      - Optional
+      - string (Default: `puppeteer-pool-config.json` in project root)
+  - Return
+    - `Promise<PuppeteerPool>`
+    - Returns PuppeteerPool Instance.
 - Instance<PuppeteerPool>.stop
-    - Description: Stop pool manager. It will close all sessions and terminate pool manager.
-    - Return
-        - `Promise<void>`
+  - Description: Stop pool manager. It will close all sessions and terminate pool manager.
+  - Return
+    - `Promise<void>`
 - Instance<PuppeteerPool>.runTask
-    - Description: Run task in pool manager. It will return result of task.
-    - Args
-        - task
-            - Required
-            - Function
-    - Return
-        - `Promise<any>`
-        - Returns result of task(Same return type with task callback return type)
+  - Description: Run task in pool manager. It will return result of task.
+  - Args
+    - task
+      - Required
+      - Function
+  - Return
+    - `Promise<any>`
+    - Returns result of task(Same return type with task callback return type)
 - Instance<PuppeteerPool>.getPoolMetrics
-    - Description: Get pool metrics. It will return metrics of pool manager.
-    - Return
-      ```json
-          {
-              memoryUsageValue: (Memory Usage in MegaBytes),
-              memoryUsagePercentage: (Memory Usage with percentage),
-              cpuUsage: (CPU Usage with percentage)
-          }
-      ```
+  - Description: Get pool metrics. It will return metrics of pool manager.
+  - Return
+    ```json
+        {
+            memoryUsageValue: (Memory Usage in MegaBytes),
+            memoryUsagePercentage: (Memory Usage with percentage),
+            cpuUsage: (CPU Usage with percentage)
+        }
+    ```
 
 ## Simple Demo
 
@@ -117,16 +117,16 @@ main();
 
 - Pool Managing
 - Config
-    - Support config customize
+  - Support config customize
 - Threshold Watcher
-    - CPU
-    - Memory
-    - Support safe pool instance reset in runtime
+  - CPU
+  - Memory
+  - Support safe pool instance reset in runtime
 - Metrics
-    - Support Metric by pool
-        - CPU usage of pool
-        - Memory usage of pool
-        - Managing session count in runtime
+  - Support Metric by pool
+    - CPU usage of pool
+    - Memory usage of pool
+    - Managing session count in runtime
 
 ## Puppeteer Pool Manager Config
 
@@ -156,11 +156,11 @@ config path, you can pass path to `bootPoolManager` function as parameter.
 
 - `width`: Width of session pool
 - `height`: Height of session pool
-    - **Inteager Validation**
-        - `width` should be larger or equal than 50
-        - `height` should be larger or equal than 50
-        - `width` should be integer
-        - `height` should be integer
+  - **Inteager Validation**
+    - `width` should be larger or equal than 50
+    - `height` should be larger or equal than 50
+    - `width` should be integer
+    - `height` should be integer
 
 ### `threshold`
 
@@ -168,10 +168,10 @@ config path, you can pass path to `bootPoolManager` function as parameter.
 - `interval`: Interval of threshold watcher
 - `cpu`: CPU threshold value
 - `memory`: Memory threshold value
-    - **Inteager Validation**
-        - `interval` should be at least 1
-        - `interval` should be integer
-        - `cpu` should be at least 1
-        - `cpu` should be integer
-        - `memory` should be at least 1
-        - `memory` should be integer
+  - **Inteager Validation**
+    - `interval` should be at least 1
+    - `interval` should be integer
+    - `cpu` should be at least 1
+    - `cpu` should be integer
+    - `memory` should be at least 1
+    - `memory` should be integer

--- a/Readme.md
+++ b/Readme.md
@@ -23,7 +23,11 @@
 
 ## Fully changed from 2.0.0
 
-The internal implementation is event-based, which significantly improves the stability. In addition, instead of relying on generic-pools to manage the pool, we have solved the problem of third-party dependency and features that were incompatible with generic-pools through our own pooling. However, there are many API changes and some features are currently disabled. If you update to 2.0.0, please be aware of the migration progress and disabled features for the changes.
+The internal implementation is event-based, which significantly improves the stability. In addition, instead of relying
+on generic-pools to manage the pool, we have solved the problem of third-party dependency and features that were
+incompatible with generic-pools through our own pooling. However, there are many API changes and some features are
+currently disabled. If you update to 2.0.0, please be aware of the migration progress and disabled features for the
+changes.
 Also cluster mode client will be provided in near future.
 
 ### API Changes
@@ -33,99 +37,97 @@ After that you can use dispatcher to control pool manager.
 
 **[ Client API ]**
 
-- StartPuppeteerPool
-
-  - Args
-    - concurrencyLevel: number
-      - Number of context level to run tasks concurrently.
-    - contextMode: ContextMode
-      - ContextMode.SHARED(Default): Each session will share local storage, cookies, etc.
-      - ContextMode.ISOLATED: Each session will have its own local storage, cookies, etc.
-    - options: [Puppeteer LaunchOptions](https://pptr.dev/api/puppeteer.launchoptions)
-    - customConfigPath: string
-      - Optional. If you want to use custom config file, you can pass path to config file.
-  - Returns
-    - dispatcher: TaskDispatcher
-      - Dispatcher instance to control pool manager.
-
-- StopPuppeteerPool
-  - Args
-    - dispatcher: TaskDispatcher
-      - Dispatcher instance returned from StartPuppeteerPool
-
-**[ TaskDispatcher API ]**
-
-- dispatchTask<T>
-
-  - Args
-    - task: RequestedTask<T>
-  - Returns
-    ```typescript
-    {
-      event: EventEmitter,
-      resultListener: Promise<unknown>
-    }
-    ```
-    - event: Check given task's state. You can listen to two event(Node.js Event) task state
-      - RUNNING: Emits when task is running
-      - DONE: Emits when task is done
-    - resultListener: Promise Object for result. resultListener is not callable. You should just await Promise to be resolve.(Same as when 'DONE' event emits)
-
-- getPoolMetrics
-  - Returns
-    ```typescript
-    {
-      memoryUsageValue: number, // Memory Usage
-      memoryUsagePercentage: number, // Memory usage percentage
-      cpuUsage: number, // CPU Usage Percentage
-    };
-    ```
+- PuppeteePool
+    - `PuppeteerPool` is singleton class. You can use `PuppeteerPool.start` to initialize pool manager.
+- PuppeteerPool.start
+    - Static Method
+    - Description: Initialize pool manager. You need to call this function to start puppeteer pool. Even if you invoke
+      this function multiple times with differenct arguments, it will return the first initialized instance.
+    - Args
+        - concurrencyLevel
+            - Required
+            - number
+        - contextMode: ContextMode
+            - Required
+            - ContextMode.ISOLATED | ContextMode.SHARED
+        - options
+            - Optional
+            - [puppeteer.LaunchOptions](https://pptr.dev/api/puppeteer.launchoptions)
+        - customConfigPath
+            - Optional
+            - string (Default: `puppeteer-pool-config.json` in project root)
+    - Return
+        - `Promise<PuppeteerPool>`
+        - Returns PuppeteerPool Instance.
+- Instance<PuppeteerPool>.stop
+    - Description: Stop pool manager. It will close all sessions and terminate pool manager.
+    - Return
+        - `Promise<void>`
+- Instance<PuppeteerPool>.runTask
+    - Description: Run task in pool manager. It will return result of task.
+    - Args
+        - task
+            - Required
+            - Function
+    - Return
+        - `Promise<any>`
+        - Returns result of task(Same return type with task callback return type)
+- Instance<PuppeteerPool>.getPoolMetrics
+    - Description: Get pool metrics. It will return metrics of pool manager.
+    - Return
+      ```json
+          {
+              memoryUsageValue: (Memory Usage in MegaBytes),
+              memoryUsagePercentage: (Memory Usage with percentage),
+              cpuUsage: (CPU Usage with percentage)
+          }
+      ```
 
 ## Simple Demo
 
 ```typescript
-import { ContextMode, StartPuppeteerPool } from '@hoplin/puppeteer-pool';
+import { ContextMode, PuppeteerPool } from "@hoplin/puppeteer-pool";
 
 async function main() {
-  const instance = await StartPuppeteerPool(3, ContextMode.ISOLATED);
+  const poolInstance = await PuppeteerPool.start(5, ContextMode.ISOLATED);
+
   const urls = [
-    'https://www.google.com',
-    'https://www.bing.com',
-    'https://www.yahoo.com',
-    'https://www.duckduckgo.com',
-    'https://www.ask.com',
+    "https://www.google.com",
+    "https://www.bing.com",
+    "https://www.yahoo.com",
   ];
-  let taskCounter = 0;
-  for (const url of urls) {
-    const taskId = `TASK_${String(++taskCounter).padStart(3, '0')}`;
-    const { event, resultListener } = await instance.dispatchTask(
-      async (page) => {
-        await page.goto(url);
-        return await page.title();
-      },
-    );
-    const result = await resultListener;
-    console.log(`[${taskId}] Result:`, result);
-    console.log('-'.repeat(50));
-  }
+
+  console.log(await poolInstance.getPoolMetrics());
+
+  const promises = urls.map((url) =>
+    poolInstance.runTask(async (page) => {
+      await page.goto(url);
+      return await page.title();
+    })
+  );
+
+  const titles = await Promise.all(promises);
+  titles.forEach((title) => console.log(title));
 }
+
 main();
+
 ```
 
 ## Support
 
 - Pool Managing
 - Config
-  - Support config customize
+    - Support config customize
 - Threshold Watcher
-  - CPU
-  - Memory
-  - Support safe pool instance reset in runtime
+    - CPU
+    - Memory
+    - Support safe pool instance reset in runtime
 - Metrics
-  - Support Metric by pool
-    - CPU usage of pool
-    - Memory usage of pool
-    - Managing session count in runtime
+    - Support Metric by pool
+        - CPU usage of pool
+        - Memory usage of pool
+        - Managing session count in runtime
 
 ## Puppeteer Pool Manager Config
 
@@ -133,20 +135,31 @@ Default config should be `puppeteer-pool-config.json` in root directory path.
 
 ### Default config setting
 
-If config file are not given or invalid path, manager will use default defined configurations. Or if you want to pass config path, you can pass path to `bootPoolManager` function as parameter.
+If config file are not given or invalid path, manager will use default defined configurations. Or if you want to pass
+config path, you can pass path to `bootPoolManager` function as parameter.
 
 ```typescript
 {
   session_pool: {
     width: 1080,
-    height: 1024,
-  },
+      height
+  :
+    1024,
+  }
+,
   threshold: {
     activate: true,
-    interval: 5,
-    cpu: 80,
-    memory: 2048,
-  },
+      interval
+  :
+    5,
+      cpu
+  :
+    80,
+      memory
+  :
+    2048,
+  }
+,
 }
 ```
 
@@ -154,11 +167,11 @@ If config file are not given or invalid path, manager will use default defined c
 
 - `width`: Width of session pool
 - `height`: Height of session pool
-  - **Inteager Validation**
-    - `width` should be larger or equal than 50
-    - `height` should be larger or equal than 50
-    - `width` should be integer
-    - `height` should be integer
+    - **Inteager Validation**
+        - `width` should be larger or equal than 50
+        - `height` should be larger or equal than 50
+        - `width` should be integer
+        - `height` should be integer
 
 ### `threshold`
 
@@ -166,10 +179,10 @@ If config file are not given or invalid path, manager will use default defined c
 - `interval`: Interval of threshold watcher
 - `cpu`: CPU threshold value
 - `memory`: Memory threshold value
-  - **Inteager Validation**
-    - `interval` should be at least 1
-    - `interval` should be integer
-    - `cpu` should be at least 1
-    - `cpu` should be integer
-    - `memory` should be at least 1
-    - `memory` should be integer
+    - **Inteager Validation**
+        - `interval` should be at least 1
+        - `interval` should be integer
+        - `cpu` should be at least 1
+        - `cpu` should be integer
+        - `memory` should be at least 1
+        - `memory` should be integer

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoplin/puppeteer-pool",
-  "version": "2.0.3",
+  "version": "2.0.6",
   "main": "dist/index.js",
   "description": "Puppeteer Pool Manager for worker server, process daemon, commands etc...",
   "repository": "https://github.com/J-Hoplin/Puppeteer-Pool.git",

--- a/src/client/rest.ts
+++ b/src/client/rest.ts
@@ -1,28 +1,81 @@
 /**
  * APIs for RESTful API mode
  */
-import { ContextMode, TaskDispatcher } from '../pool';
+import { PoolNotInitializedException } from '../error';
+import { TaskDispatcher } from '../pool/dispatcher';
+import { ContextMode } from '../pool/enum';
+import { RequestedTask } from '../types';
 import * as puppeteer from 'puppeteer';
 
-/**
- * Invoke this function to start a new Puppeteer Pool
- */
-export async function StartPuppeteerPool(
-  concurrencyLevel: number,
-  contextMode: ContextMode,
-  options?: puppeteer.LaunchOptions,
-  customConfigPath?: string,
-): Promise<TaskDispatcher> {
-  const instance = new TaskDispatcher();
-  await instance.init(concurrencyLevel, contextMode, options, customConfigPath);
-  return instance;
-}
+export class PuppeteerPool {
+  private static isInitialized = false;
+  private static dispatcherInstance: TaskDispatcher;
+  private static instance: PuppeteerPool;
 
-/**
- * Invoke this function to stop a Puppeteer Pool
- *
- * Please enroll this function in your graceful shutdown process
- */
-export async function StopPuppeteerPool(instance: TaskDispatcher) {
-  await instance.close();
+  /**
+   * Check if the instance is initialized
+   * Throw an error if the instance is not initialized
+   */
+  private checkInstanceInitalized() {
+    if (!PuppeteerPool.isInitialized) {
+      throw new PoolNotInitializedException();
+    }
+  }
+
+  /**
+   * Private constructor to make sure this class is a singleton
+   */
+  private constructor() {}
+
+  /**
+   * Invoke this function to start a new Puppeteer Pool
+   */
+  public static async start(
+    concurrencyLevel: number,
+    contextMode: ContextMode,
+    options?: puppeteer.LaunchOptions,
+    customConfigPath?: string,
+  ) {
+    if (!PuppeteerPool.isInitialized) {
+      // Initialize Task Dispatcher
+      PuppeteerPool.dispatcherInstance = new TaskDispatcher();
+      await PuppeteerPool.dispatcherInstance.init(
+        concurrencyLevel,
+        contextMode,
+        options,
+        customConfigPath,
+      );
+      // Initialize REST Client Instance
+      PuppeteerPool.instance = new PuppeteerPool();
+      // Change state to initialized
+      PuppeteerPool.isInitialized = true;
+    }
+    return PuppeteerPool.instance;
+  }
+
+  /**
+   * Invoke this function to stop a Puppeteer Pool
+   *
+   * Please enroll this function in your graceful shutdown process
+   */
+  public async stop() {
+    this.checkInstanceInitalized();
+    await PuppeteerPool.dispatcherInstance.close();
+  }
+
+  /**
+   * Invoke this function to run a task
+   */
+  public async runTask<T>(task: RequestedTask<T>) {
+    this.checkInstanceInitalized();
+    return await PuppeteerPool.dispatcherInstance.dispatchTask(task);
+  }
+
+  /**
+   * Invoke this function to get pool metrics
+   */
+  public async getPoolMetrics() {
+    this.checkInstanceInitalized();
+    return await PuppeteerPool.dispatcherInstance.getPoolMetrics();
+  }
 }

--- a/src/pool/context/context.ts
+++ b/src/pool/context/context.ts
@@ -36,6 +36,7 @@ export abstract class TaskContext {
     if (this.page) {
       if (this.page.url() !== 'about:blank') {
         // 'about:blank' can't access to local storage
+        // It'll lead to chronium security error if try to access local storage in 'about:blank'
         await this.page.evaluate(() => {
           localStorage.clear();
           sessionStorage.clear();
@@ -73,6 +74,8 @@ export abstract class TaskContext {
           error: e as Error,
         };
       } finally {
+        // Clear resource after task is done
+        // This is to prevent memory leak and to prevent waste of resource
         await this.clearResource();
       }
     }

--- a/src/pool/dispatcher.ts
+++ b/src/pool/dispatcher.ts
@@ -25,6 +25,20 @@ export enum EventTags {
   DONE = 'DONE',
 }
 
+const DEFAULT_VALUES = {
+  CONCURRENCY_LEVEL: 1,
+  CONTEXT_MODE: ContextMode.SHARED,
+  THRESHOLD: {
+    cpu: 80,
+    memory: 1024,
+  },
+  QUEUE_CHECK_INTERVAL: 100,
+} as const;
+
+const INTERNAL_EVENTS = {
+  RUN_TASK: 'RUN_TASK',
+} as const;
+
 export class TaskDispatcher extends EventEmitter {
   // Task Queue
   private taskQueue: Queue<RequestedTask> = new Queue<RequestedTask>();
@@ -37,7 +51,7 @@ export class TaskDispatcher extends EventEmitter {
   private browser: puppeteer.Browser;
 
   // Internal Event
-  private runTaskEvent = 'RUN_TASK';
+  private runTaskEvent = INTERNAL_EVENTS.RUN_TASK;
 
   // Metrics Watcher and Threshold Watcher
   private metricsWatcher: MetricsWatcher;
@@ -45,14 +59,11 @@ export class TaskDispatcher extends EventEmitter {
   // States
   private isInitialized: boolean = false;
   private isRestarting: boolean = false;
-  private concurrencyLevel: number = 1;
-  private contextMode: ContextMode = ContextMode.SHARED;
+  private concurrencyLevel: number = DEFAULT_VALUES.CONCURRENCY_LEVEL;
+  private contextMode: ContextMode = DEFAULT_VALUES.CONTEXT_MODE;
   private launchOptions: puppeteer.LaunchOptions = {};
   private poolConfig: ConfigType;
-  private threshold: { cpu: number; memory: number } = {
-    cpu: 80,
-    memory: 1024,
-  };
+  private threshold: { cpu: number; memory: number } = DEFAULT_VALUES.THRESHOLD;
 
   private taskEvents: Map<string, EventEmitter> = new Map<
     string,
@@ -80,16 +91,19 @@ export class TaskDispatcher extends EventEmitter {
   }
 
   async init(
-    concurrencyLevel: number = 1,
-    contextMode: ContextMode = ContextMode.SHARED,
+    concurrencyLevel: number = DEFAULT_VALUES.CONCURRENCY_LEVEL,
+    contextMode: ContextMode = DEFAULT_VALUES.CONTEXT_MODE,
     options: puppeteer.LaunchOptions = {},
     customPoolConfigPath?: string,
   ) {
+    // Read Config
     this.poolConfig = loadConfig(customPoolConfigPath);
     poolLogger.info('Initializing Task Dispatcher');
+    // Set instance variables
     this.concurrencyLevel = concurrencyLevel;
     this.contextMode = contextMode;
     this.launchOptions = options;
+    // Initialize Main Browser
     this.browser = await puppeteer.launch({
       ...this.launchOptions,
       defaultViewport: {
@@ -151,6 +165,7 @@ export class TaskDispatcher extends EventEmitter {
       poolLogger.info(
         `Waiting for running tasks to complete... ${this.runningContextQueue.size} task`,
       );
+      // Pending until all of the running tasks are completed
       if (this.runningContextQueue.size > 0) {
         await new Promise<void>((resolve) => {
           const checkInterval = setInterval(() => {
@@ -158,9 +173,10 @@ export class TaskDispatcher extends EventEmitter {
               clearInterval(checkInterval);
               resolve();
             }
-          }, 100);
+          }, DEFAULT_VALUES.QUEUE_CHECK_INTERVAL);
         });
       }
+      // Close browser and previous threshold watcher(If activated) and remove all of the contexts from queue
       await this.close();
       this.idleContextQueue.clear();
       this.runningContextQueue.clear();
@@ -205,8 +221,11 @@ export class TaskDispatcher extends EventEmitter {
       poolLogger.error('Fail to restart:', error);
       throw error;
     } finally {
+      // Change State to Restart
       this.isRestarting = false;
-      if (!this.taskQueue.isEmpty) {
+      // Run task as much as possible after restart. Task can be pending during restart.
+      const maxTask = Math.min(this.taskQueue.size, this.idleContextQueue.size);
+      for (let i = 0; i < maxTask; i++) {
         this.emit(this.runTaskEvent);
       }
     }
@@ -227,7 +246,8 @@ export class TaskDispatcher extends EventEmitter {
       event.once(EventTags.DONE, (result: RunTaskResponse<T>) => {
         resolve(result);
       });
-      if (!this.idleContextQueue.isEmpty) {
+      // Emit run task if idle context exist and dispatcher is not restarting state
+      if (!this.isRestarting && !this.idleContextQueue.isEmpty) {
         this.emit(this.runTaskEvent);
       }
     });
@@ -272,6 +292,7 @@ export class TaskDispatcher extends EventEmitter {
   }
 
   public async close() {
+    // Should stop threshold watcher before closing
     if (this.metricsWatcher) {
       this.metricsWatcher.stopThresholdWatcher();
     }

--- a/src/pool/enum.ts
+++ b/src/pool/enum.ts
@@ -1,0 +1,24 @@
+/**
+ * Enumeration for Task Dispatcher init
+ *
+ * SHARED: All request will share cookies and local storage
+ * ISOLATED: All request will have their own cookies and local storage (Browser Context)
+ */
+
+export enum ContextMode {
+  SHARED = 'SHARED',
+  ISOLATED = 'ISOLATED',
+}
+
+/**
+ * Enumeration for Task Dispatcher Event Tags
+ *
+ * RUNNING: Task is running
+ * PENDING: Task is pending
+ * DONE: Task is done
+ */
+export enum EventTags {
+  RUNNING = 'RUNNING',
+  PENDING = 'PENDING',
+  DONE = 'DONE',
+}

--- a/src/pool/index.ts
+++ b/src/pool/index.ts
@@ -1,2 +1,2 @@
 export * from './context';
-export * from './dispatcher';
+export * from './enum';

--- a/test.js
+++ b/test.js
@@ -1,7 +1,0 @@
-const { bootPoolManager, SessionCallbackException } = require('./dist');
-
-async function main() {
-  await bootPoolManager();
-}
-
-main();


### PR DESCRIPTION
- Update user not to use TaskDispatcher directly, Instead use `PuppeteerPool` class for client user
- Fix problem for not run tasks as much as it could after restart.
- Fix problem not to emit task and only enqueue task while instance is restarting
- Remove event handler from dispatchTask method.
   - To remove user to handle events, for potentially affecting internal behavior